### PR TITLE
create AAAI Anomaly Detection workshop redirect

### DIFF
--- a/AAAI-workshop/index.html
+++ b/AAAI-workshop/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <title>AAAI Anomaly Detection Workshop – Redirecting</title>
+
+  <!-- SEO & 301 semantic redirect -->
+  <link rel="canonical" href="html/mlchallenge-y1/aaai-workshop2024.html">
+  <meta http-equiv="refresh" content="0; url=html/mlchallenge-y1/aaai-workshop2024.html">
+
+  <script>
+    window.location.replace("html/mlchallenge-y1/aaai-workshop2024.html");
+  </script>
+</head>
+
+<body>
+  <p>
+    This page has moved to
+    <a href="html/mlchallenge-y1/aaai-workshop2024.html">html/mlchallenge-y1/aaai-workshop2024.html</a>.
+  </p>
+</body>
+
+</html>


### PR DESCRIPTION
Realized we had a direct link for the workshop that may also be out there (nsfhdr.org/AAAI-workshop), so creating a redirect. 